### PR TITLE
複数のANSIタグを含んでいる文字列を正しくパースできない不具合修正

### DIFF
--- a/Samples/Device/Arduino/NoBreakAnsiColor/NoBreakAnsiColor.ino
+++ b/Samples/Device/Arduino/NoBreakAnsiColor/NoBreakAnsiColor.ino
@@ -1,0 +1,36 @@
+#include <Arduino.h>
+
+constexpr auto ColorCountManx = 8;
+constexpr auto ForeColorBase = 30;
+constexpr auto ForeLightColorBase = 90;
+constexpr auto BackColorBase = 40;
+constexpr auto BackLightColorBase = 100;
+
+void setup()
+{
+    Serial.begin(115200);
+}
+
+void loop()
+{
+    for (auto i = 0; i < 2 * ColorCountManx; i++)
+    {
+        const auto backBase = i / ColorCountManx == 0
+                                  ? BackColorBase
+                                  : BackLightColorBase;
+        const auto backColor = backBase + i % ColorCountManx;
+
+        for (auto j = 0; j < 2 * ColorCountManx; j++)
+        {
+            const auto foreBase = j / ColorCountManx == 0
+                                      ? ForeColorBase
+                                      : ForeLightColorBase;
+            const auto foreColor = foreBase + j % ColorCountManx;
+
+            Serial.print("\x1b[" + String(foreColor) + ";" + String(backColor) + "m");
+            Serial.print("\\x1b[" + String(foreColor) + ";" + String(backColor) + "m");
+            delay(100);
+        }
+    }
+    Serial.println("\x1b[0m");
+}

--- a/Sereal/src/ansi_formatter/ansi_formatter.rs
+++ b/Sereal/src/ansi_formatter/ansi_formatter.rs
@@ -42,9 +42,8 @@ impl AnsiFormatter {
                 rich_text = rich_text.background_color(back_color);
             }
 
-            if self.color_set.is_reset {
+            if updated_color_set.is_reset {
                 self.color_set = ColorSet::default();
-                println!("Reset");
             }
 
             if rich_text.text().len() != 0 {

--- a/Sereal/src/ui/serial_view.rs
+++ b/Sereal/src/ui/serial_view.rs
@@ -141,9 +141,10 @@ impl SerialView {
 
                     // FIXME:毎回変換を行っているが、処理負荷が重いため修正する
                     for line in self.received_text.lines() {
-                        let rich_text = self.formatter.to_rich_text(&line.to_string());
                         ui.horizontal_wrapped(|ui| {
-                            ui.label(rich_text);
+                            for rich_text in self.formatter.to_rich_text(&line.to_string()) {
+                                ui.label(rich_text);
+                            }
                         });
                     }
                 });


### PR DESCRIPTION
複数のANSIタグを含んでいる文字列を正しくパースできない不具合を修正。
合わせて、フォーマットリセットのANSIタグ`\x1b[0m`が適用されていなかった不具合を修正しました。